### PR TITLE
fix(documentacao): corrige URLs e melhora layout do cabeçalho

### DIFF
--- a/apps/documentacao/README.md
+++ b/apps/documentacao/README.md
@@ -2,4 +2,4 @@
 
 Postly api key: 71fa1fdf3bbf4756825395e994c609c117b6ffed8b4930037165516439be8765
 
-## Fazendo charme o 
+## Fazendo charme o

--- a/apps/documentacao/app/docs/[project]/[slug]/page.tsx
+++ b/apps/documentacao/app/docs/[project]/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function PostPage({ params }: PostPageProps) {
               </span>
             </Link>
             <div className="flex items-center gap-4">
-              <Link href={`/${projectName}`}>
+              <Link href={`/docs/${projectName}`}>
                 <Button
                   variant="outline"
                   size="sm"

--- a/apps/documentacao/app/docs/[project]/page.tsx
+++ b/apps/documentacao/app/docs/[project]/page.tsx
@@ -74,7 +74,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
                 </div>
                 <CardTitle className="text-xl">
                   <Link
-                    href={`/${projectName}/${post.slug}`}
+                    href={`/docs/${projectName}/${post.slug}`}
                     className="hover:text-primary transition-colors"
                   >
                     {post.title}

--- a/apps/documentacao/app/page.tsx
+++ b/apps/documentacao/app/page.tsx
@@ -107,23 +107,25 @@ export default function DocumentationHome() {
                 </h1>
               </div>
             </div>
-            <Link href={"https://github.com/zappyhub/"} target="_blank">
-              <div className="flex items-center space-x-4">
-                <ThemeToggle />
-                <Button variant="outline" size="sm">
-                  <svg
-                    role="img"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <title>GitHub</title>
-                    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
-                  </svg>
-                  GitHub
-                </Button>
-              </div>
-            </Link>
+            <div className="flex gap-4">
+              <ThemeToggle />
+              <Link href={"https://github.com/zappyhub/"} target="_blank">
+                <div className="flex items-center space-x-4">
+                  <Button variant="outline" size="sm">
+                    <svg
+                      role="img"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <title>GitHub</title>
+                      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                    </svg>
+                    GitHub
+                  </Button>
+                </div>
+              </Link>
+            </div>
           </div>
         </div>
       </header>
@@ -171,7 +173,7 @@ export default function DocumentationHome() {
                 <Card className="hover:shadow-md transition-shadow cursor-pointer h-full">
                   <CardContent className="p-6 text-center">
                     <div className="flex justify-center mb-3">
-                      <div className="p-2 bg-accent/10 rounded-lg text-accent">
+                      <div className="p-2 bg-[currentColor]/30 rounded-lg text-[currentColor]">
                         {link.icon}
                       </div>
                     </div>


### PR DESCRIPTION
Corrige espaço extra no README.md.
Atualiza caminhos de links em page.tsx de [project]/[slug] e [project] para incluir prefixo "/docs", garantindo consistência nas URLs. Reorganiza cabeçalho em page.tsx, agrupando ThemeToggle e link do GitHub em um div com flex gap-4. Atualiza estilo do ícone em CardContent para usar bg-[currentColor]/30 e text-[currentColor].

Impacto do merge: Corrige navegação, melhora legibilidade do README e aprimora a apresentação visual do cabeçalho e ícones na aplicação.